### PR TITLE
Enhance Prompter Configurability and Refactor BedRockAnthropic for Flexibility

### DIFF
--- a/src/pydantic_prompter/llm_providers/__init__.py
+++ b/src/pydantic_prompter/llm_providers/__init__.py
@@ -1,3 +1,4 @@
+from typing import Type, Dict, Union
 from pydantic_prompter.annotation_parser import AnnotationParser
 from pydantic_prompter.common import logger
 from pydantic_prompter.llm_providers.bedrock_anthropic import BedRockAnthropic
@@ -5,26 +6,35 @@ from pydantic_prompter.llm_providers.bedrock_cohere import BedRockCohere
 from pydantic_prompter.llm_providers.bedrock_llama2 import BedRockLlama2
 from pydantic_prompter.llm_providers.cohere import Cohere
 from pydantic_prompter.llm_providers.openai import OpenAI
+from pydantic_prompter.llm_providers.base import LLM
 
+# Mapping of llm type and model_name prefixes to their respective classes
+LLM_MODEL_MAP: Dict[str, Dict[str, Type[LLM]]] = {
+    "openai": {
+        "default": OpenAI,
+    },
+    "bedrock": {
+        "anthropic": BedRockAnthropic,
+        "cohere": BedRockCohere,
+        "meta": BedRockLlama2,
+    },
+    "cohere": {
+        "command": Cohere,
+    }
+}
 
-def get_llm(llm: str, model_name: str, parser: AnnotationParser) -> "LLM":
-    if llm == "openai":
-        llm_inst = OpenAI(model_name, parser)
-    elif llm == "bedrock" and model_name.startswith("anthropic"):
-        logger.debug("Using bedrock provider with Anthropic model")
-        llm_inst = BedRockAnthropic(model_name, parser)
-    elif llm == "bedrock" and model_name.startswith("cohere"):
-        logger.debug("Using bedrock provider with Cohere model")
-        llm_inst = BedRockCohere(model_name, parser)
-    elif llm == "bedrock" and model_name.startswith("meta"):
-        logger.debug("Using bedrock provider with Cohere model")
-        llm_inst = BedRockLlama2(model_name, parser)
-    elif llm == "cohere" and model_name.startswith("command"):
-        logger.debug("Using Cohere model")
-        llm_inst = Cohere(model_name, parser)
-    else:
-        raise Exception(f"Model not implemented {llm}, {model_name}")
-    logger.debug(
-        f"Using {llm_inst.__class__.__name__} provider with model {model_name}"
-    )
-    return llm_inst
+def get_llm(llm: str, model_name: str, parser: AnnotationParser, model_settings: dict | None = None) -> LLM:
+    if llm not in LLM_MODEL_MAP:
+        raise ValueError(f"LLM type '{llm}' is not implemented")
+    
+    # Extract the prefix from the model name. Adjust this logic as necessary.
+    model_prefix = model_name.split('.')[0]  # Extract 'anthropic' from 'anthropic.claude-3-sonnet-20240229-v1:0'
+    
+    model_class = LLM_MODEL_MAP.get(llm, {}).get(model_prefix, None)
+
+    if model_class is None:
+        raise ValueError(f"Model prefix '{model_prefix}' for LLM type '{llm}' is not implemented")
+    
+    logger.debug(f"Using {model_class.__name__} provider with model {model_name}")
+
+    return model_class(model_name, parser, model_settings)

--- a/src/pydantic_prompter/llm_providers/bedrock_anthropic.py
+++ b/src/pydantic_prompter/llm_providers/bedrock_anthropic.py
@@ -1,12 +1,21 @@
 import json
 import random
-from typing import List
+from typing import List, Optional, Dict
 
 from pydantic_prompter.common import Message, logger
 from pydantic_prompter.llm_providers.bedrock_base import BedRock
-
+from pydantic_prompter.annotation_parser import AnnotationParser
 
 class BedRockAnthropic(BedRock):
+    def __init__(self, model_name: str, parser: AnnotationParser, model_settings: Optional[Dict] = None):
+        super().__init__(model_name, parser)
+        self.model_settings = model_settings or {
+            "temperature": random.uniform(0, 1),
+            "max_tokens": 8000,
+            "stop_sequences": ["Human:"],
+            "anthropic_version": "bedrock-2023-05-31",
+        }
+
     def _build_prompt(self, messages: List[Message], params: dict | str):
         return "\n".join([m.content for m in messages])
 
@@ -62,18 +71,17 @@ class BedRockAnthropic(BedRock):
 
         final_messages = [m.model_dump() for m in messages]
         final_messages = self.fix_messages(final_messages)
-        body = json.dumps(
-            {
-                "system": system_message,
-                "max_tokens": 8000,
-                "messages": final_messages,
-                "stop_sequences": [self._stop_sequence],
-                "temperature": random.uniform(0, 1),
-                "anthropic_version": "bedrock-2023-05-31",
-            }
-        )
 
-        response = self._boto_invoke(body)
+        # Ensure stop_sequences and anthropic_version are always included
+        body = {
+            "system": system_message,
+            "messages": final_messages,
+            "stop_sequences": self.model_settings.get("stop_sequences", [self._stop_sequence]),
+            "anthropic_version": self.model_settings.get("anthropic_version", "bedrock-2023-05-31"),
+            **self.model_settings
+        }
+
+        response = self._boto_invoke(json.dumps(body))
         res = response.get("body").read().decode()
         response_body = json.loads(res)
 

--- a/src/pydantic_prompter/prompter.py
+++ b/src/pydantic_prompter/prompter.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional, Dict
 
 from jinja2 import Template
 from retry import retry
@@ -15,11 +15,11 @@ from pydantic_prompter.llm_providers.base import LLM
 
 
 class _Pr:
-    def __init__(self, function, llm: str, model_name: str, jinja: bool):
+    def __init__(self, function, llm: str, model_name: str, jinja: bool, model_settings: Optional[Dict] = None):
         self.jinja = jinja
         self.function = function
         self.parser = AnnotationParser.get_parser(function)
-        self.llm = get_llm(llm=llm, parser=self.parser, model_name=model_name)
+        self.llm = get_llm(llm=llm, parser=self.parser, model_name=model_name, model_settings=model_settings)
 
     @retry(tries=3, delay=1, logger=logger, exceptions=(Retryable,))
     def __call__(self, *args, **inputs):
@@ -92,10 +92,11 @@ class _Pr:
 
 
 class Prompter:
-    def __init__(self, llm: str, model_name: str, jinja=False):
+    def __init__(self, llm: str, model_name: str, jinja=False, model_settings: Optional[Dict] = None):
         self.model_name = model_name
         self.llm = llm
         self.jinja = jinja
+        self.model_settings = model_settings
 
     def __call__(self, function):
         return _Pr(
@@ -103,4 +104,5 @@ class Prompter:
             jinja=self.jinja,
             llm=self.llm,
             model_name=self.model_name,
+            model_settings=self.model_settings,
         )


### PR DESCRIPTION
This pull request introduces significant improvements to the configurability and flexibility of the pydantic-prompter library, specifically focusing on the Prompter decorator and the BedRockAnthropic class. The changes allow for dynamic configuration of LLM settings and improve overall maintainability.

1. Dynamic Configuration: Added the model_settings parameter to the @Prompter decorator, allowing users to configure LLM settings dynamically. 
2. Updated _Pr Class: Modified the _Pr class to pass the model_settings to the LLM provider.
3. Support for Configurable Settings: Introduced model_settings parameter in the constructor to allow dynamic configuration of various settings such as max_tokens, temperature, top_p, top_k, stop_sequences, and anthropic_version.
4. Ensure Required Keys: Made sure stop_sequences and anthropic_version are always included in the request body.
5. Improved Error Handling and Logging: Enhanced error handling and logging for better traceability and debugging.
Refactored get_llm Function:
6. Dictionary Mapping: Introduced a dictionary (LLM_MODEL_MAP) to map LLM types and model name prefixes to their respective classes, making it easier to add new models.
7. Model Prefix Extraction: Improved the logic for extracting the model prefix from the model name.
8. Enhanced Error Handling: Provided more specific error messages when LLM types or model prefixes are not implemented.
Clear Logging: Ensured logging provides useful and clear information.

The @Prompter decorator now accepts a model_settings dictionary that allows users to customize settings such as max_tokens, temperature, top_p, top_k, stop_sequences, and anthropic_version when defining a prompt.

```python
@Prompter(llm="bedrock", model_name="anthropic.claude-3-sonnet-20240229-v1:0", jinja=True, model_settings={
    "max_tokens": 5000,
    "temperature": 0.5,
    "top_p": 0.8,
    "top_k": 40,
    "stop_sequences": ["Human:"]
})
def my_prompt_function():
    # Function implementation
```

> **NOTE!** the support to pass configuration options was only implemented in `BedRockAnthropic`... similar implementation should be applied to other model types accordingly. 